### PR TITLE
make recipe compatible with autotick-bot

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -1,5 +1,3 @@
-ace:
-- 8.0.2
 cdt_name:
 - conda
 channel_sources:

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -1,5 +1,3 @@
-ace:
-- 8.0.2
 cdt_name:
 - conda
 channel_sources:

--- a/.ci_support/linux_ppc64le_.yaml
+++ b/.ci_support/linux_ppc64le_.yaml
@@ -1,5 +1,3 @@
-ace:
-- 8.0.2
 cdt_name:
 - conda
 channel_sources:

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -2,8 +2,6 @@ MACOSX_DEPLOYMENT_TARGET:
 - '10.13'
 MACOSX_SDK_VERSION:
 - '10.13'
-ace:
-- 8.0.2
 channel_sources:
 - conda-forge
 channel_targets:

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -2,8 +2,6 @@ MACOSX_DEPLOYMENT_TARGET:
 - '11.0'
 MACOSX_SDK_VERSION:
 - '11.0'
-ace:
-- 8.0.2
 channel_sources:
 - conda-forge
 channel_targets:

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -1,5 +1,3 @@
-ace:
-- 8.0.2
 channel_sources:
 - conda-forge
 channel_targets:

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@
 /build_artifacts
 
 *.pyc
+
+# Rattler-build's artifacts are in `output` when not specifying anything.
+/output

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,25 +1,23 @@
 {% set name = "minio-server" %}
-{% set version = "RELEASE.2025-01-20T14-49-07Z" %}
-{% set sha256 = "ae4855815f9276662219debc707af1c4403d9ea502d27234f9a5d1c890f98dfc" %}
-{% set time = version|replace("RELEASE.", "") %}
+{% set version = "2025-01-20T14-49-07Z" %}
 
 package:
   name: {{ name|lower }}
-  version: {{ time|replace("-", ".")|replace("T", ".")|replace("Z", "") }}
+  version: {{ version|replace("-", ".")|replace("T", ".")|replace("Z", "") }}
 
 source:
-  url: https://github.com/minio/minio/archive/{{ version }}.tar.gz
-  sha256: {{ sha256 }}
+  url: https://github.com/minio/minio/archive/RELEASE.{{ version }}.tar.gz
+  sha256: ae4855815f9276662219debc707af1c4403d9ea502d27234f9a5d1c890f98dfc
   patches:
     # patch gen-ldflags.go to not use `git` to detect the git commit hash
     # instead use GitHub API (see build/script_env/GIT_TAG and GIT_COMMIT in build scripts)
     - patches/0001-commitID.patch
 
 build:
-  number: 0
+  number: 1
   script_env:
-    - GIT_TAG={{ version }}
-    - GIT_TIME={{ time }}
+    - GIT_TAG=RELEASE.{{ version }}
+    - GIT_TIME={{ version }}
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,7 +21,7 @@ build:
 
 requirements:
   build:
-    - "{{ compiler("go-nocgo") }} >=1.16"
+    - {{ compiler("go-nocgo") }}
     - curl
     - go-licenses
     - jq  # [not win]


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

This PR should make this feedstock compatible with the autotick-bot for automatic version updates.

xref https://github.com/regro/cf-scripts/issues/3763

<!--
Please add any other relevant info below:
-->
